### PR TITLE
Refactoring: Shared Ranking Between Games

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14,6 +14,7 @@ async def on_ready():
 # Load the slash commands extension
 bot.load_extension("commands.guess_who")
 bot.load_extension("commands.arkdle")
+bot.load_extension("commands.ranking")
 
 print("Iniciando o bot...")
 bot.start()

--- a/commands/guess_who.py
+++ b/commands/guess_who.py
@@ -142,16 +142,6 @@ async def reveal_operator(ctx, client):
     reset_round()
 
 
-async def show_ranking(ctx):
-    scores = load_scores()
-    if not scores:
-        await ctx.send("Ninguém acertou nenhum operador ainda.")
-        return
-    ranking = sorted(scores.items(), key=lambda x: x[1]["pontos"], reverse=True)
-    msg = "**🏆 Ranking de Pontuação:**\n"
-    for i, (user_id, data) in enumerate(ranking, 1):
-        msg += f"{i}. {data['username']} — {data['pontos']} ponto(s)\n"
-    await ctx.send(msg)
 
 
 class GuessWhoGame(interactions.Extension):
@@ -188,11 +178,6 @@ class GuessWhoGame(interactions.Extension):
     async def reveal(self, ctx: interactions.SlashContext):
         await reveal_operator(ctx, self.client)
 
-    @interactions.slash_command(
-        name="ranking", description="Exibe o ranking de pontuação dos usuários."
-    )
-    async def ranking(self, ctx: interactions.SlashContext):
-        await show_ranking(ctx)
 
 
 def setup(client):

--- a/commands/ranking.py
+++ b/commands/ranking.py
@@ -1,0 +1,26 @@
+import interactions
+from scores import load_scores
+
+async def show_ranking(ctx):
+    scores = load_scores()
+    if not scores:
+        await ctx.send("Ninguém acertou nenhum operador ainda.")
+        return
+    ranking = sorted(scores.items(), key=lambda x: x[1]["pontos"], reverse=True)
+    msg = "**🏆 Ranking de Pontuação:**\n"
+    for i, (user_id, data) in enumerate(ranking, 1):
+        msg += f"{i}. {data['username']} — {data['pontos']} ponto(s)\n"
+    await ctx.send(msg)
+
+class RankingExtension(interactions.Extension):
+    def __init__(self, client):
+        self.client = client
+
+    @interactions.slash_command(
+        name="ranking", description="Exibe o ranking de pontuação dos usuários."
+    )
+    async def ranking(self, ctx: interactions.SlashContext):
+        await show_ranking(ctx)
+
+def setup(client):
+    return RankingExtension(client)


### PR DESCRIPTION
Changes Made

Creation of the ranking.py module to centralize the /ranking command and ranking display logic. Removal of the /ranking command and the ranking function from the guess_who.py file. Adaptation of the bot to load the new ranking extension, allowing shared use across different games (Guess Who, Arkdle, etc.). Maintained the scoring and ranking display logic for all users. Improved code organization and modularity, facilitating future integrations and maintenance.